### PR TITLE
implement `scrollTo(posY)` & `scrollIntoView(node)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,17 @@ Properties:
 _**\* Row height:** defaults to `26`px if `TreeDataTable`'s property `rowHeight` is not set._
 
 
+## Public Methods
+
+_**`scrollTo(posY: number)`**_
+  - Scrolls the content of the table to a given position (px).
+
+_**`scrollIntoView(node: TreeDataRow, expandAncestors: boolean = true)`**_
+  - Scrolls the row representing the given node into view
+  - For **`expandAncestors`** set to `true`, the parents of the given node will expand their content. When set to `false` the state of the table will remain untouched & the row representing the first visible node down the list will be scrolled into view.
+
+These methods can be accessed by acquiring a [reference](https://reactjs.org/docs/refs-and-the-dom.html) to **`TreeDataTable`**.
+
 
 ## License
 

--- a/demo/src/DemoApp.js
+++ b/demo/src/DemoApp.js
@@ -10,9 +10,22 @@ import { generateData } from './mockData';
 type Props = { };
 type State = { };
 
+const DATA = generateData();
+
 export default class DemoApp extends Component<Props, State> {
+  table: ?TreeDataTable;
+
+  componentDidMount() {
+    const objToMatch = DATA.data[500].children[1].children[0];
+    
+    if (this.table) {
+      this.table.scrollIntoView(objToMatch);
+      console.log('scrollIntoView:', objToMatch);
+    }
+  }
+
   render () {
-    const { data, count } = generateData();
+    const { data, count } = DATA;
 
     return (
       <div className="wrapper">
@@ -48,6 +61,7 @@ export default class DemoApp extends Component<Props, State> {
         
         <p>Row count: <span>{count}</span>.</p>
         <TreeDataTable className="demo-tree-table"
+          ref={elem => {this.table = elem}}
           data={data}
           height={500}
           rowHeight={30}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cp-react-tree-table",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cp-react-tree-table",
   "umdName": "TreeDataTable",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "main": "dist/index.js",
   "umd": "dist/index.umd.js",
   "module": "dist/index.es.js",

--- a/src/component/TreeDataTable.js
+++ b/src/component/TreeDataTable.js
@@ -9,7 +9,7 @@ import BTRoot from '../model/bt_root';
 import Row from '../model/row';
 import type { TreeDataRow  } from '../model/row';
 
-import { processData, noop } from '../util';
+import { processData, noop, findNodeData } from '../util';
 
 
 
@@ -30,6 +30,8 @@ type State = {
 export default class TreeDataTable extends Component<Props, State> {
   static Column = Column;
 
+  virtualList: ?VirtualList;
+
   constructor(props: Props) {
     super(props);
     const { rowHeight } = props;
@@ -45,17 +47,60 @@ export default class TreeDataTable extends Component<Props, State> {
     const baseClass = className ? `cp_tree-table ${className}`: 'cp_tree-table';
     return (
       <VirtualList className={baseClass}
+        ref={elem => {this.virtualList = elem}}
+
         columns={children}
 
         height={height || 200}
         root={this.state.root}
         
         onScroll={onScroll || noop}
-        onToggle={(row) => this.handleOnToggle(row)}/>
+        onToggle={(row) => this._handleOnToggle(row)}/>
     );
   }
 
-  handleOnToggle = (row: Row) => {
+  // Public API
+  scrollIntoView(node: TreeDataRow, expandAncestors: boolean = true) {
+    const { root } = this.state;
+
+    const row = findNodeData(root, node);
+    if (row) {
+      const rowIndex = root.getRowIndex(row);
+      if (expandAncestors && !row.isVisible()) {
+        let ancestors: Array<Row> = [];
+        for (let currentRowIndex = Math.max(rowIndex - 1, 0), previousDepth = row.depth; currentRowIndex >= 0; currentRowIndex--) {
+          const currentRow = root.getRow(currentRowIndex);
+          
+          if (currentRow.depth === previousDepth - 1) {  // Parent
+            ancestors.push(currentRow);
+            previousDepth = currentRow.depth;
+
+            if (currentRow.isVisible()) { // From here up, all the ancestors are visible
+              break;
+            }
+          }
+
+          if (currentRow.depth === 0) {
+            break;
+          }
+        }
+
+        ancestors.forEach((row: Row) => this._handleOnToggle(row));
+      }
+
+      const posY = root.getYAtIndex(rowIndex);
+      this.scrollTo(posY);
+    }
+  }
+
+  // Public API
+  scrollTo(posY: number) {
+    if (this.virtualList) {
+      this.virtualList.scrollTop(posY);
+    }
+  }
+
+  _handleOnToggle = (row: Row) => {
     const { root } = this.state;
     const currentDepth = row.depth;
     let rowIndex = Math.min(root.getRowIndex(row) + 1, root.getSize());

--- a/src/component/VirtualList.js
+++ b/src/component/VirtualList.js
@@ -8,6 +8,7 @@ import VirtualListRow from './VirtualListRow';
 import BTRoot from '../model/bt_root';
 import Row from '../model/row';
 
+
 type Props = {
   root: BTRoot,
   columns: ChildrenArray<Element<typeof Column>>,
@@ -35,16 +36,16 @@ export default class VirtualList extends Component<Props, State> {
   container: ?HTMLElement;
 
   componentDidUpdate() {
-    this.setHeight();
+    this._setHeight();
   }
 
   componentDidMount() {
-    this.setHeight();
-    window.addEventListener("resize", this.setHeight.bind(this));
+    this._setHeight();
+    window.addEventListener("resize", this._setHeight);
   }
 
   componentWillUnmount() {
-    window.removeEventListener("resize", this.setHeight.bind(this));
+    window.removeEventListener("resize", this._setHeight);
   }
 
   render() {
@@ -77,7 +78,7 @@ export default class VirtualList extends Component<Props, State> {
       <div className={className}
         style={{ ...STYLE_LIST, height: this.props.height + 'px', }}
         ref={elem => {this.container = elem}}
-        onScroll={this.handleScroll}>
+        onScroll={this._handleScroll}>
 
         <div style={{ ...STYLE_WRAPPER, height: (root.getHeight()) + 'px', }}>
           <div style={{ ...STYLE_CONTENT, top: (contentTopOffset) + 'px' }}
@@ -90,9 +91,14 @@ export default class VirtualList extends Component<Props, State> {
     );
   }
 
+  scrollTop(posY: number = 0) {
+    if (this.container) {
+      this.container.scrollTop = posY;
+    }
+  }
 
   // virtual scroll
-  handleScroll = () => {
+  _handleScroll = () => {
     const { onScroll } = this.props;
 
     if (this.container) {
@@ -107,7 +113,7 @@ export default class VirtualList extends Component<Props, State> {
   }
 
   // virtual scroll
-  setHeight = () => {
+  _setHeight = () => {
     const { height } = this.state;
     
     if (this.container) {

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -2,6 +2,8 @@
 import Row from '../model/row';
 import type { TreeDataRow  } from '../model/row';
 
+export * from './search';
+
 
 export const processData = (data: Array<TreeDataRow>, rowHeightDefault: ?number = null) => {
   return processLevel(data, rowHeightDefault, 0, true);

--- a/src/util/search.js
+++ b/src/util/search.js
@@ -1,0 +1,17 @@
+// @flow
+import Row from '../model/row';
+import BTRoot from '../model/bt_root';
+import type { TreeDataRow  } from '../model/row';
+
+
+export const findNodeData = (root: BTRoot, dataNode: TreeDataRow): ?Row => {
+  let result;
+
+  root.mapAll((row: Row) => {
+    if (dataNode.data === row.data) {
+      result = row;
+      return true;
+    }
+  });
+  return result;
+}


### PR DESCRIPTION
`scrollTo(posY: number)`
  - Scrolls the content of the table to a given position (`px`)


`scrollIntoView(node: TreeDataRow, expandAncestors: boolean = true)`
  - Scrolls the row representing the given node into view
  - For **`expandAncestors`** set to `true`, the parents of the given node will expand their content. When set to `false` the state of the table will remain untouched & the row representing the first visible node down the list will be scrolled into view
 - [Demo](https://github.com/constantin-p/cp-react-tree-table/blob/ed5e492d8ad013e0b7ff76b4f4ef5d2b50cd0871/demo/src/DemoApp.js#L22)

`scrollTo` & `scrollIntoView` are public methods of **`TreeDataTable`** and can be accessed by acquiring a [reference](https://reactjs.org/docs/forwarding-refs.html) to the component.

```jsx
class DemoApp extends React.Component {
  table: ?TreeDataTable; // 1. reference property

  componentDidMount() {
    if (this.table) {
      // 3. API calls
      this.table.scrollIntoView(objToMatch);
      // OR
      // this.table.scrollTo(posY);
    }
  }

  render () {
    return (
      <TreeDataTable

        ref={elem => {this.table = elem}} // 2. acquiring the reference

        data={DATA}
        height={500}
        rowHeight={30}>
        <TreeDataTable.Column grow={1} renderCell={this.renderColumn} />
      </TreeDataTable>
    );
  }

  renderColumn = (data: any, metadata: RowMetadata, toggleChildren: () => void) => {
    return (
      <div className="cell-wrapper">
        <span>{data}</span>
      </div>
    );
  }
}
```